### PR TITLE
Implemented withSchema to remove string concatenation

### DIFF
--- a/src/repository.js
+++ b/src/repository.js
@@ -10,13 +10,10 @@ module.exports = class Repository {
     this.convention = di.convention
     this.table = options.table
     this.schema = options.schema
-    this.tableQualifiedName = this.schema
-      ? `${this.schema}.${this.table}`
-      : `${this.table}`
     this.entity = options.entity
     this.entityIDs = options.ids
     this.run = di.knex(options.dbConfig)
-    this.runner = di.knex(options.dbConfig)(this.tableQualifiedName)
+    this.runner = di.knex(options.dbConfig).withSchema(this.schema).from(this.table)
     this.dataMapper = DataMapper.getFrom(this.entity, this.entityIDs)
   }
 

--- a/test/queries/delete.js
+++ b/test/queries/delete.js
@@ -20,7 +20,7 @@ describe("Delete an Entity", () => {
   }
 
   const knex = () => {
-    return () => ({ where: (columns) => ({ delete: (columns) => 1 }) })
+    return { withSchema: () => { return {from: ()=> { return { where: (columns) => ({ delete: (columns) => 1 })}} }} } 
   }
 
   it("should delete an entity", async () => {

--- a/test/queries/findBy.js
+++ b/test/queries/findBy.js
@@ -26,13 +26,13 @@ describe('Query Find By', () => {
     ]
 
     const knex = () => {
-        return  () => ({
-            select: (columns) => ({
+        return { withSchema: () => { return {from: ()=> {
+           return { select: (columns) => ({
                     whereIn: (column, values) => {
                         return returnData
                     }
-            })
-        })
+            })}
+        }}}}
     }
 
     it('should return entities using table field', async () => {

--- a/test/queries/findByID.js
+++ b/test/queries/findByID.js
@@ -33,7 +33,7 @@ describe('Query Find by ID', () => {
                 return {
                   select: (columns) => ({
                     whereIn: (column, values) => {
-                      return returnData;
+                      return returnData
                     }
                   })
                 }

--- a/test/queries/findByID.js
+++ b/test/queries/findByID.js
@@ -26,14 +26,23 @@ describe('Query Find by ID', () => {
     ]
 
     const knex = () => {
-        return  () => ({
-            select: (columns) => ({
+        return {
+          withSchema: () => {
+            return {
+              from: () => {
+                return {
+                  select: (columns) => ({
                     whereIn: (column, values) => {
-                        return returnData
+                      return returnData;
                     }
-            })
-        })
-    }
+                  })
+                }
+              }
+            }
+          }
+        }
+      }
+    
 
     it('should return entities', async () => {
         //given

--- a/test/queries/insert.js
+++ b/test/queries/insert.js
@@ -20,7 +20,7 @@ describe("Insert an Entity", () => {
   }
 
   const knex = () => {
-    return () => ({ insert: (columns) => true })
+    return { withSchema: () => { return {from: ()=> {return { insert: (columns) => true }}}}}
   }
 
   it("should insert an entity", async () => {

--- a/test/queries/persist.js
+++ b/test/queries/persist.js
@@ -31,14 +31,24 @@ describe("Persist an Entity", () => {
   let querySQL
   let quetyValues
 
-  const knex = () => () => ({
-    raw: (sql, values) => {
-      querySQL = sql
-      quetyValues = values
-      return true
-    },
-    where: () => ({ update: () => 1 }),
-  })
+  const knex = () => {
+    return {
+      withSchema: () => {
+        return {
+          from: () => {
+            return {
+              raw: (sql, values) => {
+                querySQL = sql;
+                quetyValues = values;
+                return true;
+              },
+              where: () => ({ update: () => 1 }),
+            }
+          }
+        }
+      }
+    }
+  }
 
   it("should persist entities", async () => {
     //given

--- a/test/queries/persist.js
+++ b/test/queries/persist.js
@@ -38,9 +38,9 @@ describe("Persist an Entity", () => {
           from: () => {
             return {
               raw: (sql, values) => {
-                querySQL = sql;
-                quetyValues = values;
-                return true;
+                querySQL = sql
+                quetyValues = values
+                return true
               },
               where: () => ({ update: () => 1 }),
             }

--- a/test/queries/update.js
+++ b/test/queries/update.js
@@ -20,9 +20,8 @@ describe("Update an Entity", () => {
   }
 
   const knex = () => {
-    return () => ({ where: (columns) => ({ update: (columns) => 1 }) })
+    return { withSchema: () => { return {from: ()=> { return { where: (columns) => ({ update: (columns) => 1 })}} }} } 
   }
-
   it("should update an entity", async () => {
     //given
     const anEntity = givenAnEntity()


### PR DESCRIPTION
As described in issue #6 we implemented `withSchema` on construction of repository to remove string concatenation on  `tableQualifiedName` who no more exist in class.